### PR TITLE
docs: adiciona steering para criação de issues e vinculação ao board

### DIFF
--- a/.kiro/steering/github-issues.md
+++ b/.kiro/steering/github-issues.md
@@ -51,6 +51,17 @@ Informações adicionais, restrições, dependências ou links relevantes.
 5. Se uma US for grande demais, quebre em sub-issues menores mantendo o prefixo `[US-X]`.
 6. Incluir labels adequadas: `frontend`, `backend`, `ia`, `infra`, `docs`, `bug`.
 7. Toda issue deve ser atribuída a pelo menos um responsável.
+8. **Toda issue criada DEVE ser vinculada ao board do projeto** usando o comando `gh project item-add 24 --owner IA-para-DEVs-SD --url <URL_DA_ISSUE>` imediatamente após a criação da issue.
+
+## Vinculação ao Board
+
+Após criar cada issue com `gh issue create`, execute obrigatoriamente:
+
+```bash
+gh project item-add 24 --owner IA-para-DEVs-SD --url <URL_DA_ISSUE_CRIADA>
+```
+
+Isso garante que a issue apareça automaticamente no [board do projeto](https://github.com/orgs/IA-para-DEVs-SD/projects/24).
 
 ## Exemplos
 


### PR DESCRIPTION
## Descrição
Adiciona e atualiza o steering `.kiro/steering/github-issues.md` com o padrão de criação de issues no GitHub e regra de vinculação ao board do projeto.

## O que foi feito
- Steering com padrão de título (`[US-X]`, `[TECH]`, `[BUG]`, `[DOCS]`)
- Template de descrição com User Story, Critérios de Aceite e Observações
- Regras de labels, atribuição e granularidade
- Regra obrigatória de vinculação ao board via `gh project item-add`

## Referência
Closes #40
Closes #42