### PR TITLE
docs: simplificar Tecnologias no README e preencher versões nos ARCHITECTURE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,10 @@
 
 ## 🛠️ Tecnologias Utilizadas
 
-| Camada | Tecnologia | Justificativa |
-|---|---|---|
-| Frontend | Vue.js 3 + PrimeVue 4 + Tailwind CSS 4 | Composition API, componentes enterprise-ready, utilitários CSS |
-| State | Pinia | State management reativo e type-safe para Vue 3 |
-| Build | Vite 7 + TypeScript 5.9 | Build rápido, HMR, tipagem forte end-to-end |
-| Backend | Python 3.12 + FastAPI | Alta performance async, tipagem forte, ecossistema IA |
-| ORM | SQLAlchemy + Alembic | ORM maduro com migrations versionadas |
-| Banco de Dados | SQLite | Leve, sem dependências externas, ideal para MVP |
-| LLM | Google Gemini 2.5 Flash via PydanticAI | Outputs estruturados com validação, agentes inteligentes |
-| Autenticação | Google OAuth 2.0 + JWT (python-jose) | Login social sem senha, tokens stateless |
-| Infra | Docker Compose | Frontend e backend containerizados em rede local |
+Para detalhes completos com versões, consulte a seção Stack de cada módulo:
+
+- [Stack do Backend](backend/docs/ARCHITECTURE.md#stack)
+- [Stack do Frontend](frontend/docs/ARCHITECTURE.md#stack)
 
 ---
 

--- a/backend/docs/ARCHITECTURE.md
+++ b/backend/docs/ARCHITECTURE.md
@@ -10,20 +10,22 @@ API REST responsável pela lógica de negócio da plataforma MentorIA. Gerencia 
 
 ## Stack
 
-| Tecnologia | Versão / Detalhe | Função |
+| Tecnologia | Versão | Função |
 |---|---|---|
 | Python | 3.12 | Linguagem |
-| FastAPI | — | Framework web async |
-| SQLAlchemy | — | ORM |
-| Alembic | — | Migrations |
-| SQLite | — | Banco de dados |
-| Redis | — | Rate limiting (sliding window) |
-| PydanticAI | — | Agentes de IA com output estruturado |
+| FastAPI | 0.135+ | Framework web async |
+| SQLAlchemy | 2.x | ORM |
+| Alembic | 1.x | Migrations |
+| SQLite | — | Banco de dados (embutido) |
+| Redis | 5.x | Rate limiting (sliding window) |
+| PydanticAI | 0.x | Agentes de IA com output estruturado |
 | Google Gemini | 2.5 Flash | Modelo LLM |
-| Pydantic v2 | — | Validação de dados |
-| pydantic-settings | — | Configuração via .env |
-| python-jose | — | JWT (criação/verificação) |
-| authlib + httpx | — | OAuth 2.0 client |
+| Pydantic | 2.x | Validação de dados |
+| pydantic-settings | 2.x | Configuração via .env |
+| python-jose | 3.x | JWT (criação/verificação) |
+| authlib | 1.x | OAuth 2.0 client |
+| httpx | 0.x | HTTP client async |
+| uvicorn | 0.x | ASGI server |
 
 ---
 


### PR DESCRIPTION
## Resumo

Simplifica a seção Tecnologias do README para apontar diretamente para as seções Stack dos docs de arquitetura, e preenche as versões que estavam faltando na tabela do backend.

## Alterações

- **README.md** — Substituída tabela de tecnologias por links para Stack do backend e frontend
- **backend/docs/ARCHITECTURE.md** — Preenchidas versões de todas as dependências (FastAPI 0.135+, SQLAlchemy 2.x, Pydantic 2.x, etc.), separados authlib e httpx, adicionado uvicorn

Closes #74